### PR TITLE
Update config.ini.template

### DIFF
--- a/src/config.ini.template
+++ b/src/config.ini.template
@@ -103,8 +103,8 @@ starHand = 240
 upHeight = 88
 # Neutral position for centering the servo
 neutralHeight = 168
-# Lower limit for the center servo
-downHeight = 250 (CAUTION: Setting too high may cause damage)
+# Lower limit for the center servo - (CAUTION: Setting too high may cause damage)
+downHeight = 250 
 
 # Forward position for the port drive servo
 forwardPort = 400


### PR DESCRIPTION
mixed characters calling to int()on line 107, moved to comments line above.

By definition, an integer is a whole number, so an integer-type object should only have numbers (+ and - are also acceptable).