### PR TITLE
add M3 grub screws to fasteners

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Everything here is **under development** and is subject to change.
 | **Fasteners** | M3 20mm Screws | Mounting (6x needed) | [Buy](https://www.amazon.com/gp/product/B0CR6DY4SS/) |
 | | M3 14mm Screws | Mounting (40x needed) | [Buy](https://www.amazon.com/gp/product/B0D9GW9K4G/) |
 | | M3 10mm Screws | Mounting (76x needed) | [Buy](https://www.amazon.com/gp/product/B0CR6G5XWC/) |
+| | M3 Asstd Grub Screws | Mounting (6-8 needed) | [Buy](https://www.amazon.com/dp/B07N7C6HKP/) |
 
 ## Software Stack
 


### PR DESCRIPTION
the grub screws allow flush mounting of the short finger lids that have straight bore holes because they can't be countersunk so close to the edge on thin parts. 
Grubs also work for the chassis upper lid with straight bore holes.